### PR TITLE
Basic Flashcards

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,18 @@ def main():
     if table_rows:
         st.table(table_rows)
 
+        # Show cards
+        for table_row in table_rows:
+
+            # Using streamlit expander - built in
+            furigana_text = table_row['furigana']
+            if len(table_row['furigana']) <= 0:
+                furigana_text = "N/A"
+            with st.expander(f"Word: {table_row['word']} - Furigana: {furigana_text} - JLPT Level {str(table_row['level'])}"):
+                st.write(f"Romaji: {table_row['romaji']}")
+                st.write(f"Meaning: {table_row['meaning']}")
+
+
         if st.button("Ankify"):
             
             model = genanki.Model(


### PR DESCRIPTION
I created some basic flashcards that use the streamlit expander component. There will be one flashcard per word in the table.

![flashcard_expander_2](https://github.com/user-attachments/assets/d70d3489-ede1-4dea-9b87-0341ae38ce00)

The user can click on the card to reveal the answer after looking at the Japanese word, the furigana (if any), and the JLPT level.  

Changes:

- Everything from the jlpt branch
- Flashcards based on st.expander calls
- Can show/reveal answers by clicking on flashcards

Limitations:

- Question text cannot be put onto a new line.

Alternative ideas:

- [streamlit card component](https://pypi.org/project/streamlit-card/) for showing flashcards and hiding them
- [streamlit carousel component](https://pypi.org/project/streamlit-carousel/) for switching between flashcards